### PR TITLE
Add unit tests for core logic

### DIFF
--- a/src/codemods/helpers/update-imports-and-exports.test.ts
+++ b/src/codemods/helpers/update-imports-and-exports.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import jscodeshift from "jscodeshift";
+import updateImportsAndExports from "./update-imports-and-exports";
+import { getCasingFunction } from "../../lib/get-casing-function";
+
+const toKebab = getCasingFunction("kebab");
+
+function transform(source: string): string | null {
+  const j = jscodeshift.withParser("tsx");
+  const root = j(source);
+  return updateImportsAndExports(j, root, toKebab);
+}
+
+describe("updateImportsAndExports", () => {
+  it("transforms ES6 import declarations", () => {
+    const input = `import { Button } from './MyComponent';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-component"`);
+  });
+
+  it("transforms named exports with source", () => {
+    const input = `export { foo } from './MyModule';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-module"`);
+  });
+
+  it("transforms export all declarations", () => {
+    const input = `export * from './MyModule';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-module"`);
+  });
+
+  it("transforms TypeScript import type", () => {
+    const input = `import type { MyType } from './MyTypes';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-types"`);
+  });
+
+  it("transforms require() calls", () => {
+    const input = `const mod = require('./MyModule');`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-module"`);
+  });
+
+  it("transforms new URL() expressions", () => {
+    const input = `const url = new URL('./MyWorker', import.meta.url);`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-worker"`);
+  });
+
+  it("does not transform dynamic import() (tsx parser treats import() as CallExpression, not ImportExpression)", () => {
+    // jscodeshift's tsx parser parses import() as CallExpression with callee.type "Import"
+    // rather than ImportExpression, so j.ImportExpression doesn't match
+    const input = `async function load() { const mod = await import('./MyModule'); }`;
+    const output = transform(input);
+    expect(output).toBeNull();
+  });
+
+  it("does not transform dynamic() with arrow function import (same parser limitation)", () => {
+    const input = `const Component = dynamic(() => import('./MyComponent'), { ssr: false });`;
+    const output = transform(input);
+    expect(output).toBeNull();
+  });
+
+  it("leaves non-matching imports unchanged", () => {
+    const input = `import React from 'react';`;
+    const output = transform(input);
+    expect(output).toBeNull();
+  });
+
+  it("returns null when no changes are made", () => {
+    const input = `import { foo } from 'lodash';`;
+    const output = transform(input);
+    expect(output).toBeNull();
+  });
+
+  it("handles mixed imports - transforms only matching ones", () => {
+    const input = `
+import React from 'react';
+import { Button } from './MyComponent';
+import lodash from 'lodash';
+import { utils } from '../helperUtils';
+`;
+    const output = transform(input);
+    expect(output).not.toBeNull();
+    expect(output).toContain(`from 'react'`);
+    expect(output).toContain(`"./my-component"`);
+    expect(output).toContain(`from 'lodash'`);
+    expect(output).toContain(`"../helper-utils"`);
+  });
+
+  it("transforms paths with extensions", () => {
+    const input = `import { Button } from './MyComponent.tsx';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-component.tsx"`);
+  });
+
+  it("transforms @/ alias imports", () => {
+    const input = `import { Button } from '@/components/MyComponent';`;
+    const output = transform(input);
+    expect(output).toContain(`"@/components/my-component"`);
+  });
+});

--- a/src/codemods/helpers/update-imports-and-exports.test.ts
+++ b/src/codemods/helpers/update-imports-and-exports.test.ts
@@ -30,8 +30,14 @@ describe("updateImportsAndExports", () => {
     expect(output).toContain(`"./my-module"`);
   });
 
-  it("transforms TypeScript import type", () => {
+  it("transforms type-only import declarations", () => {
     const input = `import type { MyType } from './MyTypes';`;
+    const output = transform(input);
+    expect(output).toContain(`"./my-types"`);
+  });
+
+  it("transforms TSImportType expressions", () => {
+    const input = `type Foo = import('./MyTypes').Foo;`;
     const output = transform(input);
     expect(output).toContain(`"./my-types"`);
   });

--- a/src/codemods/helpers/update-source-value.test.ts
+++ b/src/codemods/helpers/update-source-value.test.ts
@@ -11,9 +11,7 @@ describe("transformPath", () => {
     });
 
     it("transforms relative ../ paths", () => {
-      expect(transformPath("../MyComponent", toKebab)).toBe(
-        "../my-component",
-      );
+      expect(transformPath("../MyComponent", toKebab)).toBe("../my-component");
     });
 
     it("transforms ~/ paths", () => {
@@ -77,23 +75,21 @@ describe("transformPath", () => {
     });
 
     it("preserves prefix in output", () => {
-      expect(transformPath("../MyComponent", toKebab)).toBe(
-        "../my-component",
-      );
+      expect(transformPath("../MyComponent", toKebab)).toBe("../my-component");
     });
   });
 
   describe("handles complex paths", () => {
     it("converts nested relative paths", () => {
-      expect(
-        transformPath("../../components/MyComponent", toKebab),
-      ).toBe("../../components/my-component");
+      expect(transformPath("../../components/MyComponent", toKebab)).toBe(
+        "../../components/my-component",
+      );
     });
 
     it("converts multiple path segments", () => {
-      expect(
-        transformPath("./uiElements/ButtonGroup", toKebab),
-      ).toBe("./ui-elements/button-group");
+      expect(transformPath("./uiElements/ButtonGroup", toKebab)).toBe(
+        "./ui-elements/button-group",
+      );
     });
 
     it("handles file with no extension in import", () => {
@@ -101,9 +97,7 @@ describe("transformPath", () => {
     });
 
     it("preserves already-converted paths", () => {
-      expect(transformPath("./my-component", toKebab)).toBe(
-        "./my-component",
-      );
+      expect(transformPath("./my-component", toKebab)).toBe("./my-component");
     });
   });
 });

--- a/src/codemods/helpers/update-source-value.test.ts
+++ b/src/codemods/helpers/update-source-value.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { transformPath } from "./update-source-value";
+import { getCasingFunction } from "../../lib/get-casing-function";
+
+const toKebab = getCasingFunction("kebab");
+
+describe("transformPath", () => {
+  describe("recognizes target prefixes", () => {
+    it("transforms relative ./ paths", () => {
+      expect(transformPath("./MyComponent", toKebab)).toBe("./my-component");
+    });
+
+    it("transforms relative ../ paths", () => {
+      expect(transformPath("../MyComponent", toKebab)).toBe(
+        "../my-component",
+      );
+    });
+
+    it("transforms ~/ paths", () => {
+      expect(transformPath("~/components/MyComponent", toKebab)).toBe(
+        "~/components/my-component",
+      );
+    });
+
+    it("transforms @/ paths", () => {
+      expect(transformPath("@/components/MyComponent", toKebab)).toBe(
+        "@/components/my-component",
+      );
+    });
+
+    it("transforms @src paths", () => {
+      expect(transformPath("@src/components/MyComponent", toKebab)).toBe(
+        "@src/components/my-component",
+      );
+    });
+
+    it("transforms @repo paths", () => {
+      expect(transformPath("@repo/components/MyComponent", toKebab)).toBe(
+        "@repo/components/my-component",
+      );
+    });
+
+    it("transforms @mono paths", () => {
+      expect(transformPath("@mono/components/MyComponent", toKebab)).toBe(
+        "@mono/components/my-component",
+      );
+    });
+
+    it("transforms # paths", () => {
+      expect(transformPath("#components/MyComponent", toKebab)).toBe(
+        "#components/my-component",
+      );
+    });
+  });
+
+  describe("leaves non-matching paths unchanged", () => {
+    it("does not transform bare module specifiers", () => {
+      expect(transformPath("react", toKebab)).toBe("react");
+    });
+
+    it("does not transform scoped packages", () => {
+      expect(transformPath("@types/node", toKebab)).toBe("@types/node");
+    });
+
+    it("does not transform lodash-style imports", () => {
+      expect(transformPath("lodash/camelCase", toKebab)).toBe(
+        "lodash/camelCase",
+      );
+    });
+  });
+
+  describe("preserves prefixes and extensions", () => {
+    it("preserves file extension", () => {
+      expect(transformPath("./MyComponent.tsx", toKebab)).toBe(
+        "./my-component.tsx",
+      );
+    });
+
+    it("preserves prefix in output", () => {
+      expect(transformPath("../MyComponent", toKebab)).toBe(
+        "../my-component",
+      );
+    });
+  });
+
+  describe("handles complex paths", () => {
+    it("converts nested relative paths", () => {
+      expect(
+        transformPath("../../components/MyComponent", toKebab),
+      ).toBe("../../components/my-component");
+    });
+
+    it("converts multiple path segments", () => {
+      expect(
+        transformPath("./uiElements/ButtonGroup", toKebab),
+      ).toBe("./ui-elements/button-group");
+    });
+
+    it("handles file with no extension in import", () => {
+      expect(transformPath("./myUtils", toKebab)).toBe("./my-utils");
+    });
+
+    it("preserves already-converted paths", () => {
+      expect(transformPath("./my-component", toKebab)).toBe(
+        "./my-component",
+      );
+    });
+  });
+});

--- a/src/codemods/helpers/update-source-value.ts
+++ b/src/codemods/helpers/update-source-value.ts
@@ -23,7 +23,7 @@ export function getUpdatedSource<T extends ASTNode>(
   return null;
 }
 
-function transformPath(
+export function transformPath(
   filePath: string,
   casingFn: (str: string) => string,
 ): string {

--- a/src/lib/convert-files.test.ts
+++ b/src/lib/convert-files.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertFileName,
+  convertSegment,
+  getNewPathPhaseOne,
+  getNewPathPhaseTwo,
+} from "./convert-files";
+import { getCasingFunction } from "./get-casing-function";
+
+const toKebab = getCasingFunction("kebab");
+const toSnake = getCasingFunction("snake");
+
+describe("convertFileName", () => {
+  it("converts camelCase file with extension", () => {
+    expect(convertFileName("myComponent.tsx", toKebab)).toBe(
+      "my-component.tsx",
+    );
+  });
+
+  it("converts camelCase file without extension", () => {
+    expect(convertFileName("myComponent", toKebab)).toBe("my-component");
+  });
+
+  it("preserves underscore-prefixed files", () => {
+    expect(convertFileName("_app.tsx", toKebab)).toBe("_app.tsx");
+    expect(convertFileName("_document.tsx", toKebab)).toBe("_document.tsx");
+  });
+
+  it("preserves all-uppercase files", () => {
+    expect(convertFileName("README", toKebab)).toBe("README");
+    expect(convertFileName("LICENSE.md", toKebab)).toBe("LICENSE.md");
+  });
+
+  it("handles multiple extensions (.d.ts)", () => {
+    // path.extname only returns the last extension
+    expect(convertFileName("myTypes.d.ts", toKebab)).toBe("my-types.d.ts");
+  });
+
+  it("handles .test.ts files", () => {
+    expect(convertFileName("myComponent.test.ts", toKebab)).toBe(
+      "my-component.test.ts",
+    );
+  });
+
+  it("works with snake_case casing function", () => {
+    expect(convertFileName("myComponent.tsx", toSnake)).toBe(
+      "my_component.tsx",
+    );
+  });
+
+  it("preserves already-converted files", () => {
+    expect(convertFileName("my-component.tsx", toKebab)).toBe(
+      "my-component.tsx",
+    );
+  });
+});
+
+describe("convertSegment", () => {
+  it("converts camelCase segment", () => {
+    expect(convertSegment("myComponent", toKebab)).toBe("my-component");
+  });
+
+  it("preserves Next.js route params with brackets", () => {
+    expect(convertSegment("[id]", toKebab)).toBe("[id]");
+    expect(convertSegment("[...slug]", toKebab)).toBe("[...slug]");
+  });
+
+  it("preserves underscore-prefixed directories", () => {
+    expect(convertSegment("_components", toKebab)).toBe("_components");
+  });
+
+  it("adds __tmp suffix when only casing differs", () => {
+    // "Mydir" -> toKebab -> "mydir", which differs only in case
+    expect(convertSegment("Mydir", toKebab)).toBe("mydir__tmp");
+  });
+
+  it("does not add __tmp when result differs in more than casing", () => {
+    expect(convertSegment("myComponent", toKebab)).toBe("my-component");
+  });
+
+  it("returns unchanged for already-converted segments", () => {
+    expect(convertSegment("my-component", toKebab)).toBe("my-component");
+  });
+
+  it("works with snake_case casing function", () => {
+    expect(convertSegment("myComponent", toSnake)).toBe("my_component");
+  });
+});
+
+describe("getNewPathPhaseOne", () => {
+  it("converts full path with multiple segments", () => {
+    expect(getNewPathPhaseOne("src/myComponents/MyButton.tsx", toKebab)).toBe(
+      "src/my-components/my-button.tsx",
+    );
+  });
+
+  it("adds __tmp suffix to segments that only differ in casing", () => {
+    expect(getNewPathPhaseOne("src/Mydir/file.ts", toKebab)).toBe(
+      "src/mydir__tmp/file.ts",
+    );
+  });
+
+  it("preserves segments that don't need conversion", () => {
+    expect(getNewPathPhaseOne("src/lib/config.ts", toKebab)).toBe(
+      "src/lib/config.ts",
+    );
+  });
+
+  it("handles nested paths", () => {
+    expect(
+      getNewPathPhaseOne("components/uiElements/ButtonGroup.tsx", toKebab),
+    ).toBe("components/ui-elements/button-group.tsx");
+  });
+
+  it("preserves underscore-prefixed file in path", () => {
+    expect(getNewPathPhaseOne("pages/_app.tsx", toKebab)).toBe(
+      "pages/_app.tsx",
+    );
+  });
+});
+
+describe("getNewPathPhaseTwo", () => {
+  it("strips __tmp suffix from directory segments", () => {
+    expect(getNewPathPhaseTwo("src/mydir__tmp/file.ts")).toBe(
+      "src/mydir/file.ts",
+    );
+  });
+
+  it("strips __tmp suffix from file basenames", () => {
+    expect(getNewPathPhaseTwo("src/myfile__tmp.ts")).toBe("src/myfile.ts");
+  });
+
+  it("leaves paths without __tmp unchanged", () => {
+    expect(getNewPathPhaseTwo("src/my-component/file.ts")).toBe(
+      "src/my-component/file.ts",
+    );
+  });
+
+  it("handles multiple __tmp segments", () => {
+    expect(getNewPathPhaseTwo("mydir__tmp/myfile__tmp.ts")).toBe(
+      "mydir/myfile.ts",
+    );
+  });
+});

--- a/src/lib/convert-files.ts
+++ b/src/lib/convert-files.ts
@@ -58,7 +58,7 @@ async function removeEmptyDirectories(
   }
 }
 
-function getNewPathPhaseOne(
+export function getNewPathPhaseOne(
   filePath: string,
   casingFn: (str: string) => string,
 ): string {
@@ -122,7 +122,7 @@ export function convertSegment(
   }
 }
 
-function getNewPathPhaseTwo(filePath: string): string {
+export function getNewPathPhaseTwo(filePath: string): string {
   const segments = filePath.split(path.sep);
 
   const newSegments = segments.map((segment, index) => {

--- a/src/lib/get-casing-function.test.ts
+++ b/src/lib/get-casing-function.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { getCasingFunction } from "./get-casing-function";
+
+const kebabCase = getCasingFunction("kebab");
+const snakeCase = getCasingFunction("snake");
+
+describe("getCasingFunction", () => {
+  it("returns kebabCase for 'kebab'", () => {
+    const fn = getCasingFunction("kebab");
+    expect(fn("camelCase")).toBe("camel-case");
+  });
+
+  it("returns snakeCase for 'snake'", () => {
+    const fn = getCasingFunction("snake");
+    expect(fn("camelCase")).toBe("camel_case");
+  });
+});
+
+describe("kebabCase", () => {
+  it("converts camelCase", () => {
+    expect(kebabCase("camelCase")).toBe("camel-case");
+  });
+
+  it("converts PascalCase", () => {
+    expect(kebabCase("PascalCase")).toBe("pascal-case");
+  });
+
+  it("converts underscores", () => {
+    expect(kebabCase("with_underscores")).toBe("with-underscores");
+  });
+
+  it("converts spaces", () => {
+    expect(kebabCase("with spaces")).toBe("with-spaces");
+  });
+
+  it("preserves already kebab-case", () => {
+    expect(kebabCase("already-kebab")).toBe("already-kebab");
+  });
+
+  it("handles single word", () => {
+    expect(kebabCase("word")).toBe("word");
+  });
+
+  it("handles acronyms like XMLParser", () => {
+    expect(kebabCase("XMLParser")).toBe("xmlparser");
+  });
+
+  it("handles consecutive capitals", () => {
+    expect(kebabCase("getHTTPResponse")).toBe("get-httpresponse");
+  });
+
+  it("handles multiple camelCase boundaries", () => {
+    expect(kebabCase("myComponentName")).toBe("my-component-name");
+  });
+});
+
+describe("snakeCase", () => {
+  it("converts camelCase", () => {
+    expect(snakeCase("camelCase")).toBe("camel_case");
+  });
+
+  it("converts PascalCase", () => {
+    expect(snakeCase("PascalCase")).toBe("pascal_case");
+  });
+
+  it("converts hyphens", () => {
+    expect(snakeCase("with-hyphens")).toBe("with_hyphens");
+  });
+
+  it("converts spaces", () => {
+    expect(snakeCase("with spaces")).toBe("with_spaces");
+  });
+
+  it("preserves already snake_case", () => {
+    expect(snakeCase("already_snake")).toBe("already_snake");
+  });
+
+  it("handles single word", () => {
+    expect(snakeCase("word")).toBe("word");
+  });
+
+  it("handles acronyms like XMLParser", () => {
+    expect(snakeCase("XMLParser")).toBe("xmlparser");
+  });
+
+  it("handles consecutive capitals", () => {
+    expect(snakeCase("getHTTPResponse")).toBe("get_httpresponse");
+  });
+
+  it("handles multiple camelCase boundaries", () => {
+    expect(snakeCase("myComponentName")).toBe("my_component_name");
+  });
+});


### PR DESCRIPTION
Add 74 unit tests across 4 test files covering the core pure functions:

- Casing functions (kebab/snake conversion with edge cases like acronyms, consecutive capitals)
- File and segment conversion (preserving underscore-prefixed files, all-uppercase files, Next.js route params, case-insensitive filesystem handling with __tmp suffix)
- Path transformation (all target prefixes, nested relative paths, extension preservation)
- AST codemod (ES6 imports, named/all exports, TypeScript import type, require(), new URL(), mixed imports)

Also exports `getNewPathPhaseOne`, `getNewPathPhaseTwo`, and `transformPath` so they can be tested directly.

Note: tests document that jscodeshift's tsx parser doesn't match `ImportExpression` for dynamic `import()` calls, making those handlers in `update-imports-and-exports.ts` dead code.

Scope: tests
Visibility: internal